### PR TITLE
feat: add support to fetch playlist details and save it as a playlist

### DIFF
--- a/components/Button.jsx
+++ b/components/Button.jsx
@@ -22,8 +22,8 @@ const Button = ({primary, hover, text, action, children, disabled = false}) => {
         borderRadius: '2rem',
         cursor: disabled ? 'not-allowed !important' : 'pointer',
         '&:hover': {
-          bg: `${hover.bg}`,
-          color: `${hover.color}`,
+          bg: hover ? `${hover.bg}` : '',
+          color: hover ? `${hover.color}` : '',
         },
         '&:focus': {
           outline: 'none',

--- a/components/Info.jsx
+++ b/components/Info.jsx
@@ -1,12 +1,10 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import {useState, useEffect} from 'react'
+import {useState} from 'react'
 import {jsx} from 'theme-ui'
 import he from 'he'
-import dayjs from 'dayjs'
-import {BiLike, BiDislike, BiShareAlt} from 'react-icons/bi'
+import {BiShareAlt} from 'react-icons/bi'
 import {MdPlaylistAdd} from 'react-icons/md'
-import formatNumber from '../utils/formatNumber'
 import PlaylistModal from './PlaylistModal'
 import ShareModal from './ShareModal'
 import {trackGAEvent} from '../utils/googleAnalytics'
@@ -51,15 +49,6 @@ const Info = ({data, start, end}) => {
             }}>
             {he.decode(data.snippet.title)}
           </h2>
-          <p
-            sx={{
-              mt: 0,
-              fontSize: [1],
-              color: 'gray',
-            }}>
-            {formatNumber(data.statistics.viewCount)} views |{' '}
-            {dayjs(data.snippet.publishedAt).format('MMM D, YYYY')}
-          </p>
         </div>
         <div
           sx={{
@@ -68,28 +57,6 @@ const Info = ({data, start, end}) => {
             justifyContent: 'space-between',
             alignItems: 'center',
           }}>
-          {/* <p sx={{mx: 2}}>
-                  <BiLike
-                    sx={{fontSize: [2], mb: '-0.2rem'}}
-                    title='Likes'
-                    aria-label='Likes'
-                  />
-                  &nbsp;
-                  <span sx={{fontSize: [1]}}>
-                    {formatNumber(data.statistics.likeCount)}
-                  </span>
-                </p> */}
-          {/* <p sx={{mx: 2}}>
-                  <BiDislike
-                    sx={{fontSize: [2], mb: '-0.2rem'}}
-                    title='Dislikes'
-                    aria-label='Dislikes'
-                  />
-                  &nbsp;
-                  <span sx={{fontSize: [1]}}>
-                    {formatNumber(data.statistics.dislikeCount)}
-                  </span>
-                </p> */}
           <div
             sx={{
               display: 'flex',
@@ -155,16 +122,6 @@ const Info = ({data, start, end}) => {
             </p>
           </div>
         </div>
-        {/* <div
-              sx={{
-                display: 'flex',
-                flexFlow: 'row wrap',
-                justifyContent: 'space-between',
-                alignItems: 'flex-start',
-              }}>
-              
-              
-            </div> */}
       </div>
 
       <ShareModal

--- a/components/Listing.jsx
+++ b/components/Listing.jsx
@@ -35,7 +35,7 @@ const Listing = ({data}) => {
           href={{
             pathname: '/video',
             // search data yields video with id has an object with a videoId key
-            // videos data yeilds video with simple id as a key
+            // videos data yields video with simple id as a key
             query: {id: item.id.videoId || item.id},
           }}
           passHref

--- a/components/Results.jsx
+++ b/components/Results.jsx
@@ -7,7 +7,12 @@ import Listing from './Listing'
 const Results = ({data, error}) => {
   return (
     <div>
-      {error && <Alert type='danger' message={error.message || error} />}
+      {error && (
+        <Alert
+          type='danger'
+          message={error?.response?.data?.error?.message || error}
+        />
+      )}
       {data && (
         <div>
           {data.items && data.items.length ? (

--- a/components/Search.jsx
+++ b/components/Search.jsx
@@ -3,7 +3,7 @@
 import {jsx} from 'theme-ui'
 import {DebounceInput} from 'react-debounce-input'
 
-const Search = ({searchTerm, updateSearch}) => {
+const Search = ({searchTerm, placeholder, updateSearch}) => {
   return (
     <div
       sx={{
@@ -30,7 +30,7 @@ const Search = ({searchTerm, updateSearch}) => {
         }}
         minLength={1}
         debounceTimeout={300}
-        placeholder='Type something or paste a youtube video link'
+        placeholder={placeholder}
         value={searchTerm}
         onChange={updateSearch}
       />

--- a/constants/playlistData.js
+++ b/constants/playlistData.js
@@ -1,0 +1,534 @@
+export default {
+  kind: 'youtube#playlistItemListResponse',
+  etag: 'Yc5G4PZfMOCkoaZgNUka_TRsrJ0',
+  items: [
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'anj8LhMqRmPLwg5kziU6Kz4EocU',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi41NkI0NEY2RDEwNTU3Q0M2',
+      snippet: {
+        publishedAt: '2021-12-01T15:20:05Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title:
+          'Pooh Shiesty - Back In Blood (feat. Lil Durk) [Official Music Video]',
+        description:
+          'Pooh Shiesty - Back In Blood (feat. Lil Durk)\nStream: https://apple.co/38qWEju\n\nShot by @JerryPHD \n\nSubscribe for more official content from POOH SHIESTY:\nhttps://poohshiesty.lnk.to/Youtube\n\nFOLLOW POOH SHIESTY\nInstagram: https://poohshiesty.lnk.to/Instagram\nTwitter: https://poohshiesty.lnk.to/Twitter\nFacebook: https://poohshiesty.lnk.to/Facebook\n\nLISTEN TO POOH SHIESTY\nApple: https://poohshiesty.lnk.to/AppleMusic\nSpotify: https://poohshiesty.lnk.to/Spotify\nSoundcloud: https://poohshiesty.lnk.to/Soundcloud\nAudiomack: https://poohshiesty.lnk.to/Audiomack\n \nThe official YouTube channel of 1017 Records artist POOH SHIESTY. Subscribe for the latest music videos, performances, and more.\n\n#BackInBlood #PoohShiesty #LilDurk #TheNew1017',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/0-Tm65i96TY/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/0-Tm65i96TY/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/0-Tm65i96TY/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/0-Tm65i96TY/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/0-Tm65i96TY/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 0,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: '0-Tm65i96TY',
+        },
+        videoOwnerChannelTitle: 'Pooh Shiesty',
+        videoOwnerChannelId: 'UCTBIIbIs83IBsy4E1BQxYBw',
+      },
+      contentDetails: {
+        videoId: '0-Tm65i96TY',
+        videoPublishedAt: '2021-01-02T17:00:01Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'IyRyY3T49ijI370j8XnKdTPSIN4',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi4yODlGNEE0NkRGMEEzMEQy',
+      snippet: {
+        publishedAt: '2021-12-01T15:20:17Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title: 'The Weeknd - Save Your Tears (Official Music Video)',
+        description:
+          "Official music video by The Weeknd performing \"Save Your Tears\"– 'After Hours' available everywhere now: http://theweeknd.co/afterhoursYD\n \n►Subscribe to The Weeknd on YouTube: http://theweeknd.co/subscribeYD \n \n►Get exclusive merch: https://shop.theweeknd.com/\n \n►Follow The Weeknd:\nhttps://twitter.com/theweeknd \nhttps://www.facebook.com/theweeknd \nhttps://www.instagram.com/theweeknd \nhttps://www.theweeknd.com \n\nDirected by Cliqua\nProduced by Roisín Audrey Moloney\nExecutive Producer: Jerad Anderson\nProduction Company: Florence\nAbel’s Costume Designer: Matt Henson\nProsthetics: Mike Marino, Prosthetic Renaissance\nDirector of Photography: Xiaolong Liu\nProduction Designer: Annie Sperling\n1st AD: Mike Alberts\nProduction Supervisor: Tori Storosh\nProduction Supervisor: Joe Keenan\nAssist. Production Supervisor: Linda Nhem\nCast Costume Designer: Lisa Madonna\nGaffer: Matt Ardine\nKey Grip: Jon Booker\nCamera Operator Nick Muller\nSteadicam Colin MacDonnell\nEditor: Miles Trahan\nColor: Matt Osbourne @ Company 3\nSound Design: Christian Stropko\nVFX: Buralqy + MADNOMAD\nOnline: Sunset Edit\nTitles: Bradley Pinkerton\n\nLyrics:\n\nOoh\nNa na, yeah\nI saw you dancing in a crowded room\nYou look so happy when I'm not with you\nBut then you saw me, caught you by surprise\nA single teardrop falling from your eye\nI don't know why I run away\nI make you cry when I run away\nYou could've asked me why I broke your heart\nYou could've told me that you fell apart\nBut you walked past me like I wasn't there\nAnd just pretended like you didn't care\nI don't know why I run away\nI make you cry when I run away\nTake me back 'cause I wanna stay\nSave your tears for another\nSave your tears for another day\nSave your tears for another day\nSo\nI made you think that I would always stay\nI said some things that I should never say\nYeah, I broke your heart like someone did to mine\nAnd now you won't love me for a second time\nI don't know why I run away, oh, girl\nSaid I make you cry when I run away\nGirl, take me back 'cause I wanna stay\nSave your tears for another\nI realize that I'm much too late\nAnd you deserve someone better\nSave your tears for another day (Ooh, yeah)\nSave your tears for another day (Yeah)\nI don't know why I run away\nI make you cry when I run away\nSave your tears for another day, ooh, girl (Ah)\nI said save your tears for another day (Ah)\nSave your tears for another day (Ah)\nSave your tears for another day (Ah)\n\n#TheWeeknd #SaveYourTears #AfterHours\n\nMusic video by The Weeknd performing Save Your Tears. © 2021 The Weeknd XO, Inc., manufactured and marketed by Republic Records, a division of UMG Recordings, Inc.\n\nhttp://vevo.ly/7MOdnq",
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/XXYlFuWEuKI/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/XXYlFuWEuKI/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/XXYlFuWEuKI/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/XXYlFuWEuKI/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/XXYlFuWEuKI/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 1,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'XXYlFuWEuKI',
+        },
+        videoOwnerChannelTitle: 'TheWeekndVEVO',
+        videoOwnerChannelId: 'UCF_fDSgPpBQuh1MsUTgIARQ',
+      },
+      contentDetails: {
+        videoId: 'XXYlFuWEuKI',
+        videoPublishedAt: '2021-01-05T17:00:12Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'eO6upWTEOEntTMuW0QPsUHLq4do',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi4wMTcyMDhGQUE4NTIzM0Y5',
+      snippet: {
+        publishedAt: '2021-12-01T15:20:40Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title: 'Lil Nas X - MONTERO (Call Me By Your Name) (Official Video)',
+        description:
+          'Official video for “MONTERO (Call Me By Your Name)” by Lil Nas X. Listen + Download: “MONTERO (Call Me By Your Name)” out now https://lilnasx.lnk.to/Montero - Put headphones on for a simulated 360 Reality Audio experience.\n \nAmazon Music - https://lilnasx.lnk.to/Montero/amazonmusic\nApple Music - https://lilnasx.lnk.to/Montero/applemusic\nAudiomack - https://lilnasx.lnk.to/Montero/audiomack\nDeezer - https://lilnasx.lnk.to/Montero/deezer\niTunes - https://lilnasx.lnk.to/Montero/itunes\nSoundcloud - https://lilnasx.lnk.to/Montero/soundcloud\nSpotify - https://lilnasx.lnk.to/Montero/spotify\nYouTube Music - https://lilnasx.lnk.to/Montero/youtubemusic\n \nSong Produced By Take A Daytrip, Omer Fedi, Roy Lenzo \n\nDirector: Tanu Muino & Lil Nas X\nWritten By: Lil Nas X\nCreative Director/Stylist: Hodo Musa\nProducer: Saul Levitz, Frank Borin, Marco De Molina & Ivanna Borin\nProduction Company: UnderWonder Content\nVisual FX: Mathematic\nChoreography: Kelly Yvonne\n\n#LILNASX #MONTERO #CALLMEBYYOURNAME\n\n“MONTERO (Call Me By Your Name)” was mixed with an immersive #360RA experience in mind, use headphones for the full effect. \n \nStream “MONTERO (Call Me By Your Name)” in full 360 Reality Audio, now available on Tidal, Amazon and Deezer. \nRegister at the link below to redeem your 3-month free trial! Visit: https://cutt.ly/music_com_LilNasX \n*Quantities are limited, while supplies last*\n \nFollow Lil Nas X\nFacebook - https://www.facebook.com/LilNasX/\nInstagram - https://www.instagram.com/lilnasx/\nTwitter - https://twitter.com/LilNasX\nTikTok - http://tiktok.com/@lilnasx\n \nhttp://www.lilnasx.com',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/6swmTBVI83k/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/6swmTBVI83k/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/6swmTBVI83k/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/6swmTBVI83k/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/6swmTBVI83k/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 2,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: '6swmTBVI83k',
+        },
+        videoOwnerChannelTitle: 'LilNasXVEVO',
+        videoOwnerChannelId: 'UCtTfSyci2urfwXXu_eRpNRA',
+      },
+      contentDetails: {
+        videoId: '6swmTBVI83k',
+        videoPublishedAt: '2021-03-26T04:00:14Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'qc-VlSZOo45B5e1VGxcQLogtZPc',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi41MjE1MkI0OTQ2QzJGNzNG',
+      snippet: {
+        publishedAt: '2021-12-01T15:20:52Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title: 'Polo G - RAPSTAR (Official Video)',
+        description:
+          'Official video for "RAPSTAR" by Polo G\n\nListen + Download "RAPSTAR" out now: https://polog.lnk.to/RAPSTAR\n\nAmazon Music - https://polog.lnk.to/RAPSTAR/amazonmusic\nApple Music - https://polog.lnk.to/RAPSTAR/applemusic\nAudiomack - https://polog.lnk.to/RAPSTAR/audiomack\nDeezer - https://polog.lnk.to/RAPSTAR/deezer\niTunes - https://polog.lnk.to/RAPSTAR/itunes\nSoundcloud - https://polog.lnk.to/RAPSTAR/soundcloud\nSpotify - https://polog.lnk.to/RAPSTAR/spotify\nYouTube Music - https://polog.lnk.to/RAPSTAR/youtubemusic\n\nLyrics\n\nCopped a BMW\nNew deposit I picked up another bag like fuck it imma count while I’m in it\nI hear planes flying crowds screaming money counting chains clinging shit I guess that’s how it sound when you winning\nI ain’t joking do it sound like I’m kidding\nI been making like two thousand a minute\nSo high up through the clouds I was swimming\nI’m probably gon’ drown when I’m in it\nI bet she gon’ get loud when I’m in it\nAnd we might have a child when I’m finished\n\nI won’t love a hoe after we fuck she can’t get near me\nOnly bitch I give a conversation to is Siri\nMy pants Amiri\nYes I’m winning clearly\nI’m the chosen one see my potential so they fear me\nLately I’ve been praying God I wonder can you hear me\nThinking about the old me I swear I miss you dearly\nStay down until you come up I’ve been sticking to that theory\nEvery day a battle I’m exhausted and I’m weary\nMake sure I smile in public when alone my eyes teary\nI fought through it all but that shit hurt me severely \nI’ve been getting high to hide behind my insecurities\nTaking different pills but I know it ain’t no \n\nCopped a BMW\nNew deposit I picked up another bag like fuck it imma count while I’m in it\nI hear planes flying crowds screaming money counting chains clinging shit I guess that’s how it sound when you winning\nI ain’t joking do it sound like I’m kidding\nI been making like two thousand a minute\nSo high up through the clouds I was swimming\nI’m probably gon’ drown when I’m in it\nI bet she gon’ get loud when I’m in it\nAnd we might have a child when I’m finished\n\nThey say I’m Pac rebirth\nNever put out a weak verse\nHomicides when we lurk\nImma step ‘til my feet hurt\nBeen putting them streets first\nWhite tee turned burgundy tee shirts\nLooking for something real, he stuck in a deep search\nAnxiety killing me I just wanna leave Earth\nWhen they ask if I’m okay it just make everything seem worse\nTrying to explain your feelings sound like something you rehearse \nStab me in my back with a clean smirk\n\nLooking so deep into your eyes I can read your thoughts\nShut the fuck- I mean please don’t talk\nI’ve done been through too much and I don’t need another loss\nPut that on every war scar for every battle that I’ve fought\n\nCopped a BMW\nNew deposit I picked up another bag like fuck it imma count while I’m in it\nI hear planes flying crowds screaming money counting chains clinging shit I guess that’s how it sound when you winning\nI ain’t joking do it sound like I’m kidding\nI been making like two thousand a minute\nSo high up through the clouds I was swimming\nI’m probably gon’ drown when I’m in it\nI bet she gon’ get loud when I’m in it\nAnd we might have a child when I’m finished\nWhen I’m finished, when I’m finished\n\nDirected by Arrad\nWritten & Co-directed by Polo G\nProduced by Riveting Entertainment\n\nFollow Polo G\nFacebook - https://www.facebook.com/pologofficial/\nInstagram - https://www.instagram.com/polo.capalot/\nTiktok - https://www.tiktok.com/@pologofficial\nTwitter - https://twitter.com/Polo_Capalot\n\n#PoloG #RAPSTAR',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/w2IhccXakkE/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/w2IhccXakkE/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/w2IhccXakkE/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/w2IhccXakkE/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/w2IhccXakkE/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 3,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'w2IhccXakkE',
+        },
+        videoOwnerChannelTitle: 'PoloGVEVO',
+        videoOwnerChannelId: 'UCojuFn_hfMyScH5hSHTBADQ',
+      },
+      contentDetails: {
+        videoId: 'w2IhccXakkE',
+        videoPublishedAt: '2021-04-09T04:00:15Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'QoLBCZrE6-vEuWWbr74tgrDMPl4',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi4wOTA3OTZBNzVEMTUzOTMy',
+      snippet: {
+        publishedAt: '2021-12-01T15:21:04Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title:
+          'DJ Khaled - EVERY CHANCE I GET (Official Music Video) ft. Lil Baby, Lil Durk',
+        description:
+          'Official music video for DJ Khaled feat. Lil Baby & Lil Durk “EVERY CHANCE I GET” off his KHALED KHALED Album \n \nKHALED KHALED ALBUM OUT NOW: https://DJKhaled.lnk.to/KHALEDKHALED\nShop DJ Khaled Merch: https://DJKhaled.lnk.to/KhaledKhaled/wethebest\nSubscribe to DJ Khaled on YouTube: https://DJKhaled.lnk.to/subscribeYD \n \nFollow DJ Khaled\nInstagram:  https://www.instagram.com/djkhaled/ \nTwitter: https://twitter.com/djkhaled \nTik Tok: https://www.tiktok.com/@djkhaled \nFacebook: https://www.facebook.com/officialdjkhaled \nWebsite: https://www.djkhaledofficial.com/ \n\nLyrics:\nWe the best music \nAnother one \nDJ Khaled \n \nScratched a million off my checklist 3 years ago \nAdd 2 zeros to the 1 I’m in a different mode \nThis my life I do what I want I be with different hoes \nYou know the pick and roll I picked her up and sent her home \nI got rich I just we get em in and get em going \nYou the traffic just got out I aint have to put em on \nWe the ones who got the numbers who put the city on \nIts the middle of the Summer I got a hoodie on \nMy demon time aint nothing nice \nI try not to wear nothing twice \nI came up off of shooting dice \nMy lil brother aint living right \nMy sister and them doing aight \nMy cousin is still serving life \nSeen a robber rob a deacon \nI seen a preacher get caught for cheating \nI break the bank for one of my peoples \nI said I’m the one they didn’t believe me \nI showed them the facts none of ya need me \nImma get cake as long as I’m breathing \nThey making it hard this shit really easy \n \nHOOK:\nImma turn up on a hater every chance that I get \nI want the biggest watch they got I don’t care if that shit hurt my wrist \nAll these hoes fuck on lil zan I wish I would claim that bitch \nThey get hard when they get guns we got a hood full of sticks \nSoon as they say we can’t come you know we run around that bitch \nYou could miss me with that shit you know I live in the mix \nMoney cars clothes and hoes \nYou know I live in the mix \nMoney cars clothes and hoes \n \nShe think I’m a regular rapper I’m not \nOne person come tell me we fucked you blocked \nWatch me run this shit to the tippidy top yea \n \nKeep going \nPut my kids in Givenchy \nShe must think 1 + 1 is 3 \nI can’t support you personally \nShe dont got a mortgage moved in with a need \nThese niggas be capping them cars be leased \nYoungest in charge I speak for the streets \nI would of naddy naddy they woke up a beast \nStruggle what made me we use to have water for dinner we didnt have nothing to eat \nSoon as I get on his ass they gonna look at me bad like damn you was fucking with me \n \nHOOK\n\nI’m from the trenches \nNigga be tougher than that \nBut really be there for attention \nBitches be talking like they really rich \nBut really be begging me under my pictures \nI give her 40 50 thousand cash to start up a business \nI spend that shit at the dentist \nI rather fuck her and pay her rent for a year just to get out of her feelings \nI’m in a lambo truck in my hood nobody gonna tell me shit \nGoing to Cali I pick my weed for sure nobody gonna mail me shit \nDice game crabs of ceelo I need cash don’t sell me shit \nBaby got its hood on smash you could tell you really rich \nDrop the low aint no room right now I took her to the o \nThen I pulled up on the lamb cause she a fan of boony mo \nI got the city on lock \nFucking up all the opps \nI be around with 3 million dollars in jewelry \nim standing on all the blocks \nThis an anthem mmmh hmmm \nDropping the 6 in the phantom \nBlack rolls truck with the all white seats remind me I’m sitting on panda \nAll of my cousin she was a dancer \nAll of my brother he was a scammer \nSit on my lap cause I’m pulling her tracks I’m not far from the back cause she calling me handsome \n \nHOOK\n \nWe The Best Music \nAnother one\n \n(C) 2021 We The Best / Epic Records, a division of Sony Music Entertainment\n \n#DJKhaled #KHALEDKHALED #EVERYCHANCEIGET',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/BTivsHlVcGU/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/BTivsHlVcGU/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/BTivsHlVcGU/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/BTivsHlVcGU/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/BTivsHlVcGU/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 4,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'BTivsHlVcGU',
+        },
+        videoOwnerChannelTitle: 'DJKhaledVEVO',
+        videoOwnerChannelId: 'UCrFB54bqp8sda4udJyNswlA',
+      },
+      contentDetails: {
+        videoId: 'BTivsHlVcGU',
+        videoPublishedAt: '2021-05-04T22:42:27Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'eA2N5_f3bHo-dhbwdmFAY2h2NdY',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi4xMkVGQjNCMUM1N0RFNEUx',
+      snippet: {
+        publishedAt: '2021-12-01T15:21:16Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title:
+          'MO3 & OG Bobby Billions - Outside (Better Days) (Official Video)',
+        description:
+          'Listen to the album "Shottaz 4Eva". Out now!\nStream: https://music.empi.re/shottaz4eva.oyd\n\n#Mo3 #Shottaz4Eva #HSM\n\nOfficial audio by M03 from the album "Shottaz 4Eva" © 2021 H$M Music / EMPIRE',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/VT0YV-hJHzg/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/VT0YV-hJHzg/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/VT0YV-hJHzg/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/VT0YV-hJHzg/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/VT0YV-hJHzg/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 5,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'VT0YV-hJHzg',
+        },
+        videoOwnerChannelTitle: 'HSM',
+        videoOwnerChannelId: 'UC_PQ7gGEKIwJv0YsnxH3dUw',
+      },
+      contentDetails: {
+        videoId: 'VT0YV-hJHzg',
+        videoPublishedAt: '2021-03-19T16:00:04Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'Wr5BM5h5lLiF9S29w4ll-HTqzDU',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi41MzJCQjBCNDIyRkJDN0VD',
+      snippet: {
+        publishedAt: '2021-12-01T15:21:29Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title:
+          'Bruno Mars, Anderson .Paak, Silk Sonic - Leave the Door Open [Official Video]',
+        description:
+          'The official music video for Bruno Mars, Anderson .Paak, Silk Sonic\'s new single "Leave the Door Open"\n\n‘An Evening with Silk Sonic’ available now: https://SilkSonic.lnk.to/AEWSSID\n\nDirected by Bruno Mars and Florent Dechard \nPhil Tayag - creative consultant\n\n\n\n🔔 Subscribe for the latest official music videos, live performances, lyric videos, official audio, and more: https://Atlantic.lnk.to/BMsubscribe\n \n🎵 Listen to the Best of Bruno Mars playlist ➤ https://bit.ly/3bbslw8\u200b \n🎵 Watch Bruno Mars’ Official Music Videos ➤ https://bit.ly/2U7I3mi\u200b \n\nGet Bruno Mars merchandise! https://brunom.rs/brunomarsstore \n\nConnect with Bruno: \nhttp://www.brunomars.com\u200b \nhttp://www.instagram.com/brunomars\u200b \nhttp://www.twitter.com/brunomars\u200b \nhttp://www.facebook.com/brunomars \n\nConnect with Anderson .Paak.: \nhttps://www.facebook.com/AndersonPaak \nhttps://www.instagram.com/anderson._paak/ \nhttps://twitter.com/AndersonPaak \n\nConnect with Silk Sonic: \nhttps://SilkSonic.lnk.to/Instagram \nhttps://SilkSonic.lnk.to/Twitter \nhttps://SilkSonic.lnk.to/Facebook \nhttps://SilkSonic.lnk.to/Spotify \nhttps://SilkSonic.lnk.to/AppleMusic \nhttps://SilkSonic.lnk.to/TikTok \n\nLyrics: \nSay baby, say baby, say baby\n\nWhat you doin \n\n(what you doin)\n\n\nWhere you at\n\n(where you at)\n\n\nOh you got plans  \n\n(you got plans)\n\n\nDon’t say that       \n\n(shut yo trap)\n\n\nI’m sippin wine     \n\n(sip sip)\n\n\nIn a robe               \n\n(drip drip)\n\n\nI look too good    \n\n(look too good)\n\n\nTo be alone         \n\n(wooohooo)\n\n\nMy house clean  \n\n(house clean)\n\n \nMy pool warm   \n\n(pool warm)\n\n \nJust shaved        \n\n(smooth like a new born)\n\n \nWe should be dancing, romancing\n\nIn the east wing and the west wing\n\nOf this mansion, what’s happenin\n\n \n\nI aint playin no games\n\nEvery word that I say \n\nIs coming straight from the heart\n\n(so if you tryna lay in these arms)\n\n \n\nImma leave the door open\n\n(imma leave the door open)\n\nImma leave the door open girl\n\n(Imma leave the door open, hopin)\n\n \nThat you feel the way I feel\n\nAnd you want me like I want you tonight baby\n\n(tell me that you’re coming through) \n\n\n \nYou’re so sweet \n\n(so sweet)\n\n \nSo tight\n\n(so tight)\n\n \nI won’t bite\n\n(ahh ahh)\n\n \nUnless you like\n\n(unless you like)\n\n \nIf you smoke\n\n(what you smoke)\n\n \n\nI got that haze\n\n(purple haze)\n\n \nAnd if you’re hungry girl I got filets\n\n(woohooo)\n\n \nOoh baby don’t keep me \n\n(waiting)\n\nThere’s so much love we could be making\n\n(Shamone)\n\nI’m talking kissing, Cuddling\n\nRose petals in the bathtub\n\nGirl lets jump in, It’s bubblin\n\n\nI aint playin no games\n\nEvery word that I say \n\nIs coming straight from the heart\n\nSo if you tryna lay in these arms\n\n( if you tryna lay in these arms)\n\n\n\nImma leave the door open\n\n(imma leave the door open)\n\nImma leave the door open girl\n\n(Imma leave the door open, hopin)\n\n\nThat you feel the way I feel\n\nAnd you want me like I want you tonight baby\n\n(tell me that you’re coming through)\n\n \nLa la laaa la la la laaa \n\n(I need you baby)\n\n \nLa la laaa la la la laaa\n\n(I gotta see you baby)\n\n\nLa la laaa la la la laaa \n\n(Girl I’m tryna give you this)\n\n(aaaaahhhhhhhhhh)\n\n\nImma leave my door open, baby\n\n(imma leave the door open)\n\nImma leave, imma leave my door open girl\n\n(Imma leave the door open, hopin)\n\nAnd I’m hopin\n\n\n\nHopin that you feel the way I feel\n\nAnd you want me like I want you tonight baby\n\n(tell me that you’re coming through)\n\n \n\nLa la laaa la la la laaa\n\nTell me\n\n(Tell me that you’re coming through)\n\n \n\nWoo, woo-woo, woo, woo-woo,woo\n\nWoo-woo\n\nWoo, woo-woo, woo, woo-woo,woo\n\nWoo-woo\n\n \n\nLa la laaa la la la laaa\n\n(Tell me that you’re coming through)\n\n \n\nGirl, I’m here just waiting for you\n\nCome on over, I’ll adore you\n\n(I gotta know)\n\n(La la laaa la la la laaa)\n\nI’m waiting, waiting, waiting for you\n\n \n\n(Tell me that you’re coming through)\n\nGirl, I’m here just waiting for you\n\nCome on over, I’ll adore you\n\n\nThe official YouTube channel of Atlantic Records artist Bruno Mars. 11x GRAMMY Award winner and 27x GRAMMY Award nominee Bruno Mars is a celebrated singer, songwriter, producer, and musician with iconic hits like "The Lazy Song", "That\'s What I Like", "Just The Way You Are", "24K Magic", "Locked Out Of Heaven", and "When I Was Your Man". His legendary body of work also includes blockbuster albums such as Doo-Wops & Hooligans, Unorthodox Jukebox, and 24K Magic, as well as era-defining collaborations like "Uptown Funk" with Mark Ronson, "Finesse" with Cardi B, and "Nothin\' On You" with B.o.B. Forever classic, yet supremely innovative, Bruno continues to redefine music, style, and popular culture, pushing the boundaries of pop, R&B, funk, soul, hip-hop, and dance, and remains as influential as ever.\n\n#BrunoMars #AndersonPaak #SilkSonic #LeaveTheDoorOpen',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/adLGHcj_fmA/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/adLGHcj_fmA/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/adLGHcj_fmA/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/adLGHcj_fmA/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/adLGHcj_fmA/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 6,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'adLGHcj_fmA',
+        },
+        videoOwnerChannelTitle: 'Bruno Mars',
+        videoOwnerChannelId: 'UCoUM-UJ7rirJYP8CQ0EIaHA',
+      },
+      contentDetails: {
+        videoId: 'adLGHcj_fmA',
+        videoPublishedAt: '2021-03-05T05:00:00Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'qtITmd8ftmmtMES5A2K2qSliQzE',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi5DQUNERDQ2NkIzRUQxNTY1',
+      snippet: {
+        publishedAt: '2021-12-01T15:21:42Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title: 'Cardi B - Up [Official Music Video]',
+        description:
+          'Cardi B - Up\r\nStream/Download - https://cardib.lnk.to/CardiUp\n\nSubscribe for more official content from Cardi B: https://CardiB.lnk.to/Subscribe\r\n\r\nFollow Cardi B\r\nhttp://cardibofficial.com\r\nhttp://Twitter.com/IAmCardiB\r\nhttp://Facebook.com/IAmCardiB\r\nhttp://Instagram.com/f/iamcardib\r\nhttp://Soundcloud.com/IAmCardiB\r\n\r\nExclusive Bardi Gang merchandise available here: http://smarturl.it/BardiGangMerchYT\r\n\r\nThe official YouTube channel of Atlantic Records artist Cardi B. Subscribe for the latest music videos, performances, and more.\n\nLABEL\nAtlantic Records\nCommissioner: Kareem Johnson / OverScene LLC\nSVP / Head of Marketing:  Marsha St. Hubert\nVideo Operations for Atlantic Records: Lily Thrall\nPRODUCTION\nProd Co: UnderWonder Content\nDirector: Tanu Muino\nExec Producer: Frank Borin & Ivanna Borin\nProducer: Tay Hawes\nDirector of Photography: Nikita Kuzmenko\nProduction Designer: Brandon Mendez\n1st AD: Jonas Morales\nEditor: Vinnie Hobbs\nColor: Dave Hussey\nBeauty/VFX: Max Colt\nChoreography: Sean Bankhead\nCARDI B GLAM\nStyling: Kollin Carter\nHair: Tokyo Stylez\nMakeup: Erika LaPearl \nNails: Marie Nailz',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/rCiBgLOcuKU/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/rCiBgLOcuKU/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/rCiBgLOcuKU/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/rCiBgLOcuKU/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/rCiBgLOcuKU/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 7,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'rCiBgLOcuKU',
+        },
+        videoOwnerChannelTitle: 'Cardi B',
+        videoOwnerChannelId: 'UCxMAbVFmxKUVGAll0WVGpFw',
+      },
+      contentDetails: {
+        videoId: 'rCiBgLOcuKU',
+        videoPublishedAt: '2021-02-05T05:00:11Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'K5ZL4cI4DJu-LCkI52SCEg9j11I',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi45NDk1REZENzhEMzU5MDQz',
+      snippet: {
+        publishedAt: '2021-12-01T15:21:54Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title: 'Olivia Rodrigo - drivers license (Official Video)',
+        description:
+          'Listen to ‘drivers license’ out now: https://smarturl.it/driverslicense\u200b\nPre-order the debut album SOUR: https://OliviaRodrigo.lnk.to/preorder\n\nFollow Olivia Rodrigo:\nInstagram: https://instagram.com/oliviarodrigo\nTwitter: https://twitter.com/Olivia_Rodrigo\nFacebook: https://www.facebook.com/OliviaRodrigoOfficial\nYouTube: https://youtube.com/oliviarodrigomusic\nTikTok: https://tiktok.com/@livbedumb\nStore: https://smarturl.it/oliviarodrigoshop\n\nMusic video by Olivia Rodrigo performing drivers license. © 2021 Olivia Rodrigo, under exclusive license to Geffen Records',
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/ZmDBbnmKpqQ/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/ZmDBbnmKpqQ/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/ZmDBbnmKpqQ/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/ZmDBbnmKpqQ/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/ZmDBbnmKpqQ/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 8,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'ZmDBbnmKpqQ',
+        },
+        videoOwnerChannelTitle: 'OliviaRodrigoVEVO',
+        videoOwnerChannelId: 'UCxE5jEls-T0QtlTHT8lI1lw',
+      },
+      contentDetails: {
+        videoId: 'ZmDBbnmKpqQ',
+        videoPublishedAt: '2021-01-08T05:00:22Z',
+      },
+    },
+    {
+      kind: 'youtube#playlistItem',
+      etag: 'ME8gkA__lNM7hbD6BeJTP022QS0',
+      id: 'UExicGk2WmFodE9INEFOUHNKM0JiTENfZnB4TmFyVGF5Vi5GNjNDRDREMDQxOThCMDQ2',
+      snippet: {
+        publishedAt: '2021-12-01T15:22:06Z',
+        channelId: 'UCBR8-60-B28hp2BmDPdntcQ',
+        title: 'Rod Wave - Street Runner (Official Video)',
+        description:
+          "#rodwave #streetrunner #soulfly\nSoulFly Tour Dates : https://soulflytour.com/\nStream SoulFly: http://smarturl.it/SoulFlyRodWave\n\nPre-save the \"SoulFly\" Album: https://music.apple.com/us/album/soulfly/1557600260\n\nBuy Merch: https://thebottomboysurvivor.com\n\nFollow Rod Wave:\n► Instagram: https://www.instagram.com/rodwave/?hl=en\n► Twitter: https://twitter.com/rodwave\n► SoundCloud: https://soundcloud.com/rodwave\n► YouTube: https://smarturl.it/RWYTSub\n\nVoicemail excerpt from “I Miss You” by Sarah Lyons\nYouTube Link - https://youtu.be/zv_R96MRzys\nInstagram - @sarah_lyoness\nTwitter - @sarahlyoness\n\n\"Street Runner\" Lyrics\n\nVERSE\nSorry i missed your call i was on a jet \nI been so zoned out tryna figure out whats next\nSo scared to feel i'm calculating my every step\nGotta watch my back and keep my strap but nonetheless\nI think about you when i'm gone wishing i could hold ya \nProlly home wishing someone come and love you how they posed to \nAnd i hope you see this letter before it's too late \nOut here chasing my dream don't get in the way \nI blame my struggles and my uncles for my hustling ways\nI'm way in michigan looking at real estate\nLord knows i wanna lay you down but i'm chasing cake\nCan't go back broke stay on the go that's all that's on my brain\n\nBRIDGE\nShe tell me fuck you i hate you then i love you\ncan't blame you\nShe say i love but don't trust you can't change you \nI just hope we don't end up how they do crash and burn on the shaderoom \n\nCHORUS\nStreetrunner gotta stop running sometime\nI'm in yo city tonight \nAnd these lights make me feel so inspired\nGoing higher and higher and higher\nTaking me higher\nHigher and higher and Higher",
+        thumbnails: {
+          default: {
+            url: 'https://i.ytimg.com/vi/AeaR5QbXgpM/default.jpg',
+            width: 120,
+            height: 90,
+          },
+          medium: {
+            url: 'https://i.ytimg.com/vi/AeaR5QbXgpM/mqdefault.jpg',
+            width: 320,
+            height: 180,
+          },
+          high: {
+            url: 'https://i.ytimg.com/vi/AeaR5QbXgpM/hqdefault.jpg',
+            width: 480,
+            height: 360,
+          },
+          standard: {
+            url: 'https://i.ytimg.com/vi/AeaR5QbXgpM/sddefault.jpg',
+            width: 640,
+            height: 480,
+          },
+          maxres: {
+            url: 'https://i.ytimg.com/vi/AeaR5QbXgpM/maxresdefault.jpg',
+            width: 1280,
+            height: 720,
+          },
+        },
+        channelTitle: 'YouTube',
+        playlistId: 'PLbpi6ZahtOH4ANPsJ3BbLC_fpxNarTayV',
+        position: 9,
+        resourceId: {
+          kind: 'youtube#video',
+          videoId: 'AeaR5QbXgpM',
+        },
+        videoOwnerChannelTitle: 'RodWave',
+        videoOwnerChannelId: 'UCenjunBhBhvKjfDAESnoppw',
+      },
+      contentDetails: {
+        videoId: 'AeaR5QbXgpM',
+        videoPublishedAt: '2021-03-10T05:00:13Z',
+      },
+    },
+  ],
+  pageInfo: {
+    totalResults: 10,
+    resultsPerPage: 50,
+  },
+}

--- a/pages/api/playlist.js
+++ b/pages/api/playlist.js
@@ -1,0 +1,20 @@
+import axios from 'axios'
+import playlistData from '../../constants/PlaylistData'
+
+const playlist = async (req, res) => {
+  const {searchTerm} = req.query
+  try {
+    const response = await axios.get(
+      `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,contentDetails&maxResults=50&playlistId=${searchTerm}&key=${process.env.YOUTUBE_API_V3}`
+    )
+    res.status(200).json(response.data)
+  } catch (error) {
+    if (error.response) {
+      res.status(error.response.status).send(error.response.data)
+    }
+    res.send(error)
+  }
+  //res.status(200).json(playlistData)
+}
+
+export default playlist

--- a/pages/api/playlist.js
+++ b/pages/api/playlist.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import playlistData from '../../constants/PlaylistData'
+import playlistData from '../../constants/playlistData'
 
 const playlist = async (req, res) => {
   const {searchTerm} = req.query

--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-// import searchData from '../../constants/SearchData'
+// import searchData from '../../constants/searchData'
 
 const search = async (req, res) => {
   const {searchTerm} = req.query

--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-// import SearchData from '../../constants/SearchData'
+// import searchData from '../../constants/SearchData'
 
 const search = async (req, res) => {
   const {searchTerm} = req.query
@@ -14,7 +14,7 @@ const search = async (req, res) => {
     }
     res.send(error)
   }
-  // res.status(200).json(SearchData)
+  // res.status(200).json(searchData)
 }
 
 export default search

--- a/pages/playlist.js
+++ b/pages/playlist.js
@@ -7,7 +7,14 @@ import Layout from '../components/Layout'
 import Alert from '../components/Alert'
 import dayjs from 'dayjs'
 import VideoListing from '../components/VideoListing'
-import {BiSave, BiShareAlt, BiTrash} from 'react-icons/bi'
+import {
+  BiPencil,
+  BiCheck,
+  BiX,
+  BiSave,
+  BiShareAlt,
+  BiTrash,
+} from 'react-icons/bi'
 import Loader from '../components/Loader'
 import axios from 'axios'
 import siteUrl from './../utils/siteUrl'
@@ -21,6 +28,9 @@ export default function Playlist({name, info, image, fetchData}) {
   const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [details, setDetails] = useState(undefined)
+  const [error, setError] = useState(undefined)
+  const [playlistName, setPlaylistName] = useState(name)
+  const [showPlaylistInput, setShowPlaylistInput] = useState(false)
   const [showSave, setShowSave] = useState(false)
   const [showShareModal, setShowShareModal] = useState(false)
   const [showModal, setShowModal] = useState(false)
@@ -140,6 +150,36 @@ export default function Playlist({name, info, image, fetchData}) {
     })
   }
 
+  const editPlaylist = () => {
+    const playlists = JSON.parse(localStorage.getItem('playlists'))
+    if (playlists[playlistName]) {
+      setError(
+        `Playlist with name '${playlistName}' already exist. Try a different name!`
+      )
+    } else {
+      setError(undefined)
+      playlists[playlistName] = {
+        ...playlists[name],
+        name: playlistName,
+      }
+      delete playlists[name]
+      localStorage.setItem('playlists', JSON.stringify(playlists))
+      setShowPlaylistInput(false)
+      router.push({
+        pathname: '/playlist',
+        query: {
+          id: playlistName,
+        },
+      })
+    }
+  }
+
+  const cancelEditPlaylist = () => {
+    setPlaylistName(name)
+    setShowPlaylistInput(false)
+    setError(undefined)
+  }
+
   const deleteVideo = (v) => {
     const playlists = JSON.parse(localStorage.getItem('playlists'))
     let deleteIndex = null
@@ -214,46 +254,140 @@ export default function Playlist({name, info, image, fetchData}) {
                   flexDirection: 'column',
                   justifyContent: 'center',
                   alignItems: 'center',
+                  textAlign: 'center',
                   mt: 0,
                 }}>
-                <h2 sx={{mb: 0}}>{details.name}</h2>
-                <p>
-                  <span>{dayjs(details.created).format('MMM D, YYYY')}</span>
-                  <span style={{margin: 'auto 1rem'}}>|</span>
-                  <span>
-                    {details.videos
-                      ? `${details.videos.length} ${pluralizeText(
-                          details.videos.length,
-                          'video'
-                        )}`
-                      : '0 videos'}
-                  </span>
-                </p>
-                <p sx={{mt: 0, position: 'relative'}}>
-                  {showSave && (
-                    <BiSave
+                <div
+                  sx={{
+                    px: 4,
+                    py: 2,
+                    border: '1px solid gray',
+                    borderRadius: '25px',
+                  }}>
+                  {showPlaylistInput ? (
+                    <Fragment>
+                      <input
+                        type='text'
+                        placeholder='Playlist Name'
+                        sx={{
+                          bg: 'search',
+                          color: 'text',
+                          borderWidth: '1px',
+                          borderStyle: 'solid',
+                          borderColor: 'search',
+                          borderRadius: '2rem',
+                          width: '75%',
+                          mt: 2,
+                          py: 2,
+                          px: 4,
+                          fontFamily: 'light',
+                          fontSize: [2],
+                          outline: 'none',
+                        }}
+                        value={playlistName}
+                        onChange={(e) => {
+                          setPlaylistName(e.target.value)
+                        }}
+                      />
+                      <span sx={{mx: 1}}>
+                        <BiCheck
+                          sx={{
+                            ...iconStyle,
+                            p: 2,
+                            fontSize: '36px',
+                            mx: 0,
+                            mb: -2,
+                          }}
+                          title='Edit playlist'
+                          aria-label='Edit'
+                          onClick={editPlaylist}
+                        />
+                      </span>
+                      <span>
+                        <BiX
+                          sx={{
+                            ...iconStyle,
+                            p: 2,
+                            fontSize: '36px',
+                            mx: 0,
+                            mb: -2,
+                          }}
+                          title='Cancel Edit'
+                          aria-label='Cancel Edit'
+                          onClick={cancelEditPlaylist}
+                        />
+                      </span>
+                      {error && (
+                        <p
+                          sx={{
+                            mt: 1,
+                            mx: 'auto',
+                            width: '70%',
+                            color: 'dangerBorder',
+                            fontSize: 0,
+                            lineHeight: 1,
+                          }}>
+                          {error}
+                        </p>
+                      )}
+                    </Fragment>
+                  ) : (
+                    <h2 sx={{mb: 0}}>
+                      {playlistName}
+                      <span sx={{ml: 1}}>
+                        <BiPencil
+                          sx={{
+                            ...iconStyle,
+                            p: 2,
+                            fontSize: 5,
+                            mx: 0,
+                            mb: -2,
+                          }}
+                          title='Edit playlist'
+                          aria-label='Edit'
+                          onClick={() => setShowPlaylistInput(true)}
+                        />
+                      </span>
+                    </h2>
+                  )}
+                  <p>
+                    <span>{dayjs(details.created).format('MMM D, YYYY')}</span>
+                    <span style={{margin: 'auto 1rem'}}>|</span>
+                    <span>
+                      {details.videos
+                        ? `${details.videos.length} ${pluralizeText(
+                            details.videos.length,
+                            'video'
+                          )}`
+                        : '0 videos'}
+                    </span>
+                  </p>
+                  <p sx={{mt: 0, position: 'relative'}}>
+                    {showSave && (
+                      <BiSave
+                        sx={iconStyle}
+                        title='Save playlist'
+                        aria-label='Share'
+                        onClick={savePlaylist}
+                      />
+                    )}
+                    <BiShareAlt
                       sx={iconStyle}
-                      title='Save playlist'
+                      title='Share playlist on'
                       aria-label='Share'
-                      onClick={savePlaylist}
+                      onClick={() => setShowShareModal(true)}
                     />
-                  )}
-                  <BiShareAlt
-                    sx={iconStyle}
-                    title='Share playlist on'
-                    aria-label='Share'
-                    onClick={() => setShowShareModal(true)}
-                  />
-                  {!showSave && (
-                    <BiTrash
-                      sx={iconStyle}
-                      title='Delete playlist'
-                      onClick={() =>
-                        openModal('playlist', name, null, deletePlaylist)
-                      }
-                    />
-                  )}
-                </p>
+                    {!showSave && (
+                      <BiTrash
+                        sx={iconStyle}
+                        title='Delete playlist'
+                        onClick={() =>
+                          openModal('playlist', name, null, deletePlaylist)
+                        }
+                      />
+                    )}
+                  </p>
+                </div>
               </div>
               {details.videos && (
                 <div sx={{mt: 4, mb: 3}}>


### PR DESCRIPTION
This PR closes the issue #11 

### Updates:

- `Search` is refined and classified into two sections i.e. `video` and `playlist`
- Fetch playlist details based on the playlist Id
- Save the above playlist on TrimTube
- Ability to `edit` a playlist name
- Refactor code
- Minor bug fixes

### Demo

https://vimeo.com/673967473