### PR TITLE
fix(player): correct playlist advancement in loop mode

### DIFF
--- a/components/Player.jsx
+++ b/components/Player.jsx
@@ -12,6 +12,11 @@ const Player = ({
 }) => {
   const containerRef = useRef(null)
   const playerRef = useRef(null)
+  // True while a freshly loaded cue has not started playing yet. When
+  // loadVideoById reloads the SAME video id (e.g. the next trim of the same
+  // song), the iframe can re-emit the previous cue's `ended` event before the
+  // new trim starts playing; that stale event must not advance the playlist.
+  const pendingPlayRef = useRef(false)
 
   // Keep the latest props readable inside the stable YT event handlers,
   // since those handlers are registered only once.
@@ -62,6 +67,7 @@ const Player = ({
   // subsequent videos via loadVideoById keeps the sound — so auto-advancing
   // playlists don't need a manual tap on each video.
   const loadVideo = (player, id, startTime, endTime) => {
+    pendingPlayRef.current = true
     const opts = {
       videoId: id,
       startSeconds: Number(startTime) || 0,
@@ -147,10 +153,18 @@ const Player = ({
       } else if (event.data === 0) {
         if (ls === 'LOOP_VIDEO') {
           startVideo(player, s)
-        } else {
+        } else if (!pendingPlayRef.current) {
+          pendingPlayRef.current = true
           vn ? updateVideoNumber(vn) : startVideo(player, s)
         }
+        // A stale `ended` arriving while the next cue (possibly the same video
+        // id with a different trim) has not started playing yet is ignored so
+        // the playlist advances only once and same-id trims don't get skipped.
       } else {
+        if (event.data === 1) {
+          // the freshly loaded cue is actually playing — accept a future `ended`
+          pendingPlayRef.current = false
+        }
         player.getCurrentTime().then((currentTime) => {
           // fix the iframe issue playing video from the beginning
           // even though start time is different

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trimtube",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trimtube",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trimtube",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "TrimTube is a web application which allows the user to search for YouTube videos or paste any YouTube video link. This app also features a media player that allows the user to trim and loop any portion of a YouTube video with ability to save the video(s) to a playlist.",
   "author": "Sai Nikhil <contact@iamsainikhil.com>",
   "engines": {

--- a/pages/video.js
+++ b/pages/video.js
@@ -64,10 +64,14 @@ export default function Video({videoData, videoTitle, videoImage, error}) {
     let videoNumber = 1
     for (let i = 0; i < playlist?.videos.length; i++) {
       const {id, start: startTime, end: endTime} = playlist?.videos[i]
+      // Untrimmed videos (e.g. YouTube Shorts) are stored with start/end of
+      // 0/null while the player state keeps 0 as well; normalize both sides so
+      // the exact entry is always found and loop mode advances instead of
+      // treating the video as a repeat-one.
       if (
         id === videoId &&
-        Number(startTime) === start &&
-        Number(endTime) === end
+        (Number(startTime) || 0) === (start || 0) &&
+        (Number(endTime) || 0) === (end || 0)
       ) {
         return videoNumber
       }


### PR DESCRIPTION
## Summary

Fixes two playlist auto-advance bugs in loop mode: songs of the same video ID with different trims were being skipped, and YouTube Shorts (untrimmed videos) refused to advance and repeated the same clip instead of moving to the next track.

## Changes

### Player auto-advance
- `components/Player.jsx`: Ignore a stale YouTube `ended` event that the iframe re-emits when `loadVideoById` reloads the *same* video ID for the next trim, so the playlist advances exactly once per real end instead of skipping that trim.
- `components/Player.jsx`: Keep the original start-time correction on the `playing` state (previously dropped guard would restart trims at 00:00).
- `pages/video.js`: Normalize start/end when resolving the current playlist position, so untrimmed videos (stored with `start`/`end` of `0`/`null`) always match and advance rather than silently repeating.

### Version
- `package.json` / `package-lock.json`: bump app version to 1.0.2.

## Testing

1. Create a playlist containing two or more trims of the *same* video ID (e.g. `0–10s` and `10–20s`) plus another track; enable playlist loop.
2. Verify each trim plays in order — no trims are skipped — and the playlist wraps back to the start.
3. Add a YouTube Short to a playlist, enable playlist loop, and verify it advances to the next video when it ends instead of repeating.
4. Verify trimmed videos still start at their configured start time (not 00:00) and respect their end time.